### PR TITLE
Fix issue with false typo for short domains, e.g. db.com converts to me.com

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,10 @@ class EmailValidation {
       type === 'blacklist' && result.errors.push(type)
     } else {
       let smallestDistance = result.domain.length
+      const match = /^(.+?)\.([^.]+)$/.exec(result.domain);
+      if (match) {
+        smallestDistance = match[1].length;
+      }
       for (const domain of popularDomains) {
         const distance = levenstein(domain, result.domain)
         if (distance > 0 && distance < maxDistance && distance < smallestDistance) {


### PR DESCRIPTION
BTW, me.com isn't disposable