### PR TITLE
Adding feature to whitelist domains and disallow as default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Email Validation can be configured with more advanced options as an object:
 - `blacklist` _(Array)_ Add some email domains you want to blacklist (default is [])
 - `allowFreemail` _(Boolean)_ Allow free emails such as @gmail.com, ... (default is false)
 - `allowDisposable` _(Boolean)_ Allow disposable emails such as @trashmail.com, ... (default is false)
+- `defaultType` _(String)_ Define the default behavior when a domain didn't match any rules, you can choose between valid or invalid (default is valid)
 
 You can for example choose to allow freemails, and add a domain baddomain.com in addition to the preconfigured list
 
@@ -99,7 +100,7 @@ const ev = new EmailValidation({ allowFreemail: true, blacklist: ['baddomain.com
 // This one should have result.valid = true because we allowed free mails such as gmail.com
 ev.check('random@gmail.com')
 
-// But this one is blacklisted now 
+// But this one is blacklisted now
 ev.check('paul@baddomain.com')
 
 ```
@@ -108,6 +109,13 @@ Or if you want to disallow all free mails, except gmail.com :
 
 ```javascript
 const ev = new EmailValidation({ whitelist: ['gmail.com'] })
+
+```
+
+Or if you want to only accept one single domain and disallow anything else:
+
+```javascript
+const ev = new EmailValidation({ whitelist: ['random.com'], defaultType: 'invalid' })
 
 ```
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ const defaultOptions = {
   whitelist: [],
   blacklist: [],
   allowFreemail: false,
-  allowDisposable: false
+  allowDisposable: false,
+  defaultType: 'valid'
 }
 
 class EmailValidation {
@@ -37,11 +38,14 @@ class EmailValidation {
     result.email = email.trim().toLowerCase()
     result.domain = result.email.split('@').pop()
 
+    var whitelisted = false;
+
     const type = this.domains[result.domain]
     if (type) {
       type === 'disposable' && !this.options.allowDisposable && result.errors.push(type)
       type === 'freemail' && !this.options.allowFreemail && result.errors.push(type)
       type === 'blacklist' && result.errors.push(type)
+      type === 'whitelist' && (whitelisted = true)
     } else {
       let smallestDistance = result.domain.length
       for (const domain of popularDomains) {
@@ -54,7 +58,13 @@ class EmailValidation {
       }
     }
 
-    if (!result.errors.length) result.valid = true
+    if (!result.errors.length) {
+      if(whitelisted == true | this.options.defaultType === 'valid') {
+        result.valid = true
+      } else {
+        result.errors.push(this.options.defaultType)
+      }
+    }
     return result
   }
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ class EmailValidation {
     result.email = email.trim().toLowerCase()
     result.domain = result.email.split('@').pop()
 
-    var whitelisted = false;
+    var whitelisted = false
 
     const type = this.domains[result.domain]
     if (type) {
@@ -59,7 +59,7 @@ class EmailValidation {
     }
 
     if (!result.errors.length) {
-      if(whitelisted == true | this.options.defaultType === 'valid') {
+      if (whitelisted === true | this.options.defaultType === 'valid') {
         result.valid = true
       } else {
         result.errors.push(this.options.defaultType)

--- a/index.spec.js
+++ b/index.spec.js
@@ -191,11 +191,10 @@ describe('EmailValidation', () => {
       expect(result.errors[0]).eq('invalid')
     })
     it('should say domain random.com is valid because random.com has been whitelisted despite of default validation is not set to accept', () => {
-      ev.setOptions({ defaultType: 'invalid', whitelist:['random.com'] })
+      ev.setOptions({ defaultType: 'invalid', whitelist: ['random.com'] })
       const result = ev.check('random@random.com')
       expect(result).to.be.an('object')
       expect(result.valid).eq(true)
     })
   })
-
 })

--- a/index.spec.js
+++ b/index.spec.js
@@ -181,4 +181,21 @@ describe('EmailValidation', () => {
       expect(result.valid).eq(true)
     })
   })
+  describe('Default validation should be configurable', () => {
+    const ev = new EmailValidation()
+    it('should say domain random.com is invalid because default validation is not set to accept, normally random.com should have been accepted', () => {
+      ev.setOptions({ defaultType: 'invalid' })
+      const result = ev.check('random@random.com')
+      expect(result).to.be.an('object')
+      expect(result.valid).eq(false)
+      expect(result.errors[0]).eq('invalid')
+    })
+    it('should say domain random.com is valid because random.com has been whitelisted despite of default validation is not set to accept', () => {
+      ev.setOptions({ defaultType: 'invalid', whitelist:['random.com'] })
+      const result = ev.check('random@random.com')
+      expect(result).to.be.an('object')
+      expect(result.valid).eq(true)
+    })
+  })
+
 })


### PR DESCRIPTION
Adding feature to whitelist domains and disallow as default behavior if no other rule has matched.

A new config option as been added:
- `defaultType` _(String)_ Define the default behavior when a domain didn't match any rules, you can choose between valid or invalid (default is valid)

Here are tests added:

```
describe('Default validation should be configurable', () => {
    const ev = new EmailValidation()
    it('should say domain random.com is invalid because default validation is not set to accept, normally random.com should have been accepted', () => {
      ev.setOptions({ defaultType: 'invalid' })
      const result = ev.check('random@random.com')
      expect(result).to.be.an('object')
      expect(result.valid).eq(false)
      expect(result.errors[0]).eq('invalid')
    })
    it('should say domain random.com is valid because random.com has been whitelisted despite of default validation is not set to accept', () => {
      ev.setOptions({ defaultType: 'invalid', whitelist:['random.com'] })
      const result = ev.check('random@random.com')
      expect(result).to.be.an('object')
      expect(result.valid).eq(true)
    })
  })
```

