### PR TITLE
Remove rocketmail.com from the disposable list

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -8430,7 +8430,6 @@
   "rockaroundtheclock.co.uk": "disposable",
   "rockchick.co.uk": "disposable",
   "rocked.co.uk": "disposable",
-  "rocketmail.com": "disposable",
   "rockets1.com": "disposable",
   "rocketship.com": "freemail",
   "rockfan.com": "disposable",


### PR DESCRIPTION
I've had some complaints from legitimate users that their rocketmail.com email address is getting blocked. It looks like it's just an alias for old yahoo email addresses. Either way, I don't think it's disposable.

# Changes

- Removed `rocketmail.com` (disposable) used by Yahoo http://rocketmail.com https://en.wikipedia.org/wiki/RocketMail
